### PR TITLE
Fix plugin on latest versions of Gatsby

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -88,8 +88,8 @@ function linkNodes(nodes) {
     });
 }
 
-exports.sourceNodes = async ({ boundActionCreators }, { userID, clientID }) => {
-  const { createNode } = boundActionCreators;
+exports.sourceNodes = async ({ actions }, { userID, clientID }) => {
+  const { createNode } = actions;
 
   try {
     // Fetch data


### PR DESCRIPTION
On latest versions of Gatsby, `createNode` is undefined because it's being unpacked from the wrong place. This fixes it, tested it locally with my own portfolio